### PR TITLE
Phone Gap Build id unique

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,8 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
-    id="com.phonegap.plugins.PushPlugin"
-    version="2.4.0">
+    id="com.dclarkconsulting.phonegap.plugins.PushPlugin"
+    version="1.0">
 
   <name>PushPlugin</name>
 	<author>Bob Easterday</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,8 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
-    id="com.dclarkconsulting.phonegap.plugins.PushPlugin"
-    version="1.0">
+    id="com.phonegap.plugins.PushPlugin"
+    version="2.4.0">
 
   <name>PushPlugin</name>
 	<author>Bob Easterday</author>


### PR DESCRIPTION
PhoneGap Build requires a unique id for naming/finding/using a plugin.  The previous id was used by pushplugin so it cannot be used again.  Changing the id field should allow us to include the file when we build our app.

Honestly, this is the first thing I have ever tried in GitHub and I don't know phonegap that well.  I'm not sure what I am doing is right.  We will see.... 