### PR TITLE
Allow for multi-line notification messages on Android

### DIFF
--- a/src/android/com/plugin/gcm/GCMIntentService.java
+++ b/src/android/com/plugin/gcm/GCMIntentService.java
@@ -111,6 +111,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 		String message = extras.getString("message");
 		if (message != null) {
 			mBuilder.setContentText(message);
+			mBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
 		} else {
 			mBuilder.setContentText("<missing message content>");
 		}


### PR DESCRIPTION
Hi Morten,
Thank you so much for sharing this meteor package, it has really made my life simpler!

Would you mind adding this small line of code to your fork which allows the notification messages on Android to be multi-line instead of the truncated single line version.

All the best,
Maxime
